### PR TITLE
Add -clear-counters-after-show option

### DIFF
--- a/cmdargs.c
+++ b/cmdargs.c
@@ -112,6 +112,7 @@ double skipcount;
 double flushcount;
 double maxcount;
 double stat_interval;
+int clear_counters_after_show;
 int informat = DEFVAL_informat;
 long on_trigger;
 long off_trigger;
@@ -280,6 +281,13 @@ struct arglist args[] = {
         "Show statistics after every U references",
         match_1arg, val_scale_uintd, NULL,
         summary_uintd, help_scale_uintd
+    },
+    {
+        "-clear-counters-after-show", 2, &clear_counters_after_show, NULL,
+        NULL,
+        "After showing statistics, clear counters but keep cache state",
+        match_0arg, val_0arg, NULL,
+        summary_0arg, help_0arg
     },
     {
         "-informat", 2, &informat, DEFSTR_informat,

--- a/cmdargs.h
+++ b/cmdargs.h
@@ -89,6 +89,7 @@ extern double skipcount;    /* for -skipcount */
 extern double flushcount;   /* for -flushcount */
 extern double maxcount;     /* for -maxcount */
 extern double stat_interval;    /* for -stat-interval */
+extern int clear_counters_after_show;   /* for clear_counters_after_show */
 extern long on_trigger;     /* for -on-trigger */
 extern long off_trigger;    /* for -off-trigger */
 extern int stat_idcombine;  /* for -stat-idcombine */

--- a/cmdmain.c
+++ b/cmdmain.c
@@ -84,6 +84,7 @@ extern int do1arg(const char*, const char*);
 extern void doargs(int, char**);
 extern void summarize_caches(d4cache*, d4cache*);
 extern void dostats(void);
+extern void clear_counters(void);
 extern void do1stats(d4cache*);
 extern d4memref next_trace_item(void);
 #if !D4CUSTOM
@@ -1137,6 +1138,31 @@ void dostats()
     }
 }
 
+void clear_counters()
+{
+    int lev;
+    int i, j;
+    for (lev = 0;  lev < maxlevel;  lev++) {
+        for (j = 0;  j < 3;  j++) {
+            if (levcache[j][lev] != NULL) {
+                levcache[j][lev]->multiblock = 0;
+                levcache[j][lev]->bytes_read = 0;
+                levcache[j][lev]->bytes_written = 0;
+                for (i = 0;  i < 2 * D4NUMACCESSTYPES;  i++) {
+                    levcache[j][lev]->fetch[i] = 0;
+                    levcache[j][lev]->miss[i] = 0;
+                    levcache[j][lev]->blockmiss[i] = 0;
+                    levcache[j][lev]->comp_miss[i] = 0;
+                    levcache[j][lev]->comp_blockmiss[i] = 0;
+                    levcache[j][lev]->cap_miss[i] = 0;
+                    levcache[j][lev]->cap_blockmiss[i] = 0;
+                    levcache[j][lev]->conf_miss[i] = 0;
+                    levcache[j][lev]->conf_blockmiss[i] = 0;
+                }
+            }
+        }
+    }
+}
 
 #define NONZERO(i) (((i)==0.0) ? 1.0 : (double)(i)) /* avoid divide-by-zero exception */
 /*
@@ -1943,6 +1969,8 @@ int main(int argc, char** argv)
         tmaxcount += 1;
         if (tintcount > 0 && (tintcount -= 1) <= 0) {
             dostats();
+            if (clear_counters_after_show)
+                clear_counters();
             tintcount = stat_interval;
         }
         if (flcount > 0 && (flcount -= 1) <= 0) {


### PR DESCRIPTION
-clear-counters-after-show is used together with -stat-interval. After showing statistics (enabled by -stat-interval), it clears counters to zero but keeps cache state.

This is for understanding the hit/miss status of a particular time range. For example, the hit rate after warm-up.